### PR TITLE
feat: Add sourceMap option

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ export default {
       include: /\.[jt]sx?$/, // default
       exclude: /node_modules/, // default
       watch: process.argv.includes('--watch'),
+      sourceMap: false, // defaults to true
       minify: process.env.NODE_ENV === 'production',
       target: 'es2015' // default, or 'es20XX', 'esnext'
       jsxFactory: 'React.createElement',

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,6 +10,7 @@ export type Options = {
   include?: FilterPattern
   exclude?: FilterPattern
   watch?: boolean
+  sourceMap?: boolean
   minify?: boolean
   target?: Target
   jsxFactory?: string
@@ -89,6 +90,7 @@ export default (options: Options = {}): Plugin => {
         jsxFactory: options.jsxFactory,
         jsxFragment: options.jsxFragment,
         define: options.define,
+        sourcemap: options.sourceMap !== false,
       })
 
       printWarnings(id, result, this)

--- a/src/index.ts
+++ b/src/index.ts
@@ -90,7 +90,7 @@ export default (options: Options = {}): Plugin => {
         jsxFactory: options.jsxFactory,
         jsxFragment: options.jsxFragment,
         define: options.define,
-        sourcemap: options.sourceMap !== false,
+        sourcemap: options.sourceMap
       })
 
       printWarnings(id, result, this)


### PR DESCRIPTION
Option name + default are based on the description here: https://rollupjs.org/guide/en/#source-code-transformations

Generates source maps by default, unless you set `sourceMap: false`