### PR TITLE
feat: Allow JSX syntax in .js files

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,8 +26,8 @@ export default {
       target: 'es2017' // default, or 'es20XX', 'esnext'
       jsxFactory: 'React.createElement',
       jsxFragment: 'React.Fragment'
-      // Allow JSX syntax in .js and .ts files
-      allowJsx: false, // default, or true
+      // Specify loader for extension(s)
+      loader: { '.js': 'jsx' },
       // Like @rollup/plugin-replace
       define: {
         __VERSION__: '"x.y.z"'

--- a/README.md
+++ b/README.md
@@ -26,6 +26,8 @@ export default {
       target: 'es2017' // default, or 'es20XX', 'esnext'
       jsxFactory: 'React.createElement',
       jsxFragment: 'React.Fragment'
+      // Allow JSX syntax in .js and .ts files
+      allowJsx: false, // default, or true
       // Like @rollup/plugin-replace
       define: {
         __VERSION__: '"x.y.z"'

--- a/README.md
+++ b/README.md
@@ -26,8 +26,6 @@ export default {
       target: 'es2017' // default, or 'es20XX', 'esnext'
       jsxFactory: 'React.createElement',
       jsxFragment: 'React.Fragment'
-      // Specify loader for extension(s)
-      loader: { '.js': 'jsx' },
       // Like @rollup/plugin-replace
       define: {
         __VERSION__: '"x.y.z"'

--- a/src/index.ts
+++ b/src/index.ts
@@ -80,7 +80,7 @@ export default (options: Options = {}): Plugin => {
 
       let loader = extname(id).slice(1) as Loader
 
-      if (!!options.allowJsx) {
+      if (options.allowJsx) {
         if (loader === 'js') {
           loader = 'jsx'
         } else if (loader === 'ts') {

--- a/src/index.ts
+++ b/src/index.ts
@@ -14,7 +14,7 @@ export type Options = {
   target?: Target
   jsxFactory?: string
   jsxFragment?: string
-  allowJsx?: boolean
+  loader?: { [ext: string]: Loader }
   define?: {
     [k: string]: string
   }
@@ -78,15 +78,8 @@ export default (options: Options = {}): Plugin => {
         return null
       }
 
-      let loader = extname(id).slice(1) as Loader
-
-      if (options.allowJsx) {
-        if (loader === 'js') {
-          loader = 'jsx'
-        } else if (loader === 'ts') {
-          loader = 'tsx'
-        }
-      }
+      const ext = extname(id)
+      const loader = options.loader?.[ext] || (ext.slice(1) as Loader)
 
       if (!loaders.includes(loader) || !service) {
         return null

--- a/src/index.ts
+++ b/src/index.ts
@@ -14,6 +14,7 @@ export type Options = {
   target?: Target
   jsxFactory?: string
   jsxFragment?: string
+  allowJsx?: boolean
   define?: {
     [k: string]: string
   }
@@ -77,7 +78,15 @@ export default (options: Options = {}): Plugin => {
         return null
       }
 
-      const loader = extname(id).slice(1) as Loader
+      let loader = extname(id).slice(1) as Loader
+
+      if (!!options.allowJsx) {
+        if (loader === 'js') {
+          loader = 'jsx'
+        } else if (loader === 'ts') {
+          loader = 'tsx'
+        }
+      }
 
       if (!loaders.includes(loader) || !service) {
         return null

--- a/src/index.ts
+++ b/src/index.ts
@@ -14,7 +14,6 @@ export type Options = {
   target?: Target
   jsxFactory?: string
   jsxFragment?: string
-  loader?: { [ext: string]: Loader }
   define?: {
     [k: string]: string
   }
@@ -78,8 +77,10 @@ export default (options: Options = {}): Plugin => {
         return null
       }
 
-      const ext = extname(id)
-      const loader = options.loader?.[ext] || (ext.slice(1) as Loader)
+      const ext = extname(id).slice(1)
+      const loader = (options.jsxFactory && ['js', 'ts'].includes(ext)
+        ? `${ext}x`
+        : ext) as Loader
 
       if (!loaders.includes(loader) || !service) {
         return null


### PR DESCRIPTION
We're slowly migrating our project to TypeScript, but like this issue: https://github.com/egoist/rollup-plugin-esbuild/issues/38, we still have a lot of JSX in JS.