### PR TITLE
feat: use `this.meta.watchMode` for checking watch mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,6 @@ export default {
       // All options are optional
       include: /\.[jt]sx?$/, // default, inferred from `loaders` option
       exclude: /node_modules/, // default
-      watch: process.argv.includes('--watch'),
       sourceMap: false, // default
       minify: process.env.NODE_ENV === 'production',
       target: 'es2017' // default, or 'es20XX', 'esnext'

--- a/example/rollup.config.js
+++ b/example/rollup.config.js
@@ -1,7 +1,5 @@
 const esbuild = require('../dist/index')
 
-const isDev = process.env.NODE_ENV === 'development'
-
 export default {
   input: 'example/index.js',
   output: {
@@ -10,7 +8,6 @@ export default {
   },
   plugins: [
     esbuild({
-      watch: isDev,
       minify: !isDev,
     }),
   ],

--- a/src/index.ts
+++ b/src/index.ts
@@ -15,7 +15,6 @@ const defaultLoaders: { [ext: string]: Loader } = {
 export type Options = {
   include?: FilterPattern
   exclude?: FilterPattern
-  watch?: boolean
   sourceMap?: boolean
   minify?: boolean
   target?: string | string[]
@@ -67,7 +66,7 @@ export default (options: Options = {}): Plugin => {
   let service: Service | undefined
 
   const stopService = () => {
-    if (!options.watch && service) {
+    if (service) {
       service.stop()
       service = undefined
     }
@@ -147,7 +146,7 @@ export default (options: Options = {}): Plugin => {
 
     buildEnd(error) {
       // Stop the service early if there's error
-      if (error) {
+      if (error && !this.meta.watchMode) {
         stopService()
       }
     },
@@ -170,7 +169,9 @@ export default (options: Options = {}): Plugin => {
     },
 
     generateBundle() {
-      stopService()
+      if (!this.meta.watchMode) {
+        stopService()
+      }
     },
   }
 }


### PR DESCRIPTION
Resolves #52 

It seems that Rollup provides a way to check for watch mode that should be compatible with the `rollup.watch` API as well.

Are there still legitimate reasons to keep around the `watch` property?
