### PR TITLE
Handle '[!] (plugin esbuild) Error: Invalid option: "jsxFactory"' error

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -125,14 +125,18 @@ export default (options: Options = {}): Plugin => {
           ? {}
           : await getOptions(dirname(id), options.tsconfig)
 
-      const result = await service.transform(code, {
+      const config = {
         loader,
         target: options.target || defaultOptions.target || 'es2017',
         jsxFactory: options.jsxFactory || defaultOptions.jsxFactory,
         jsxFragment: options.jsxFragment || defaultOptions.jsxFragment,
         define: options.define,
         sourcemap: options.sourceMap,
-      })
+      }
+
+      Object.keys(config).forEach(key => config[key] === undefined && delete config[key])
+
+      const result = await service.transform(code, config)
 
       printWarnings(id, result, this)
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -125,14 +125,14 @@ export default (options: Options = {}): Plugin => {
           ? {}
           : await getOptions(dirname(id), options.tsconfig)
 
-      const config = {
+      const config: Options = {
         loader,
         target: options.target || defaultOptions.target || 'es2017',
         jsxFactory: options.jsxFactory || defaultOptions.jsxFactory,
         jsxFragment: options.jsxFragment || defaultOptions.jsxFragment,
         define: options.define,
         sourcemap: options.sourceMap,
-      } as Record<string, unknown>
+      }
 
       Object.keys(config).forEach(key => config[key] === undefined && delete config[key])
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -132,7 +132,7 @@ export default (options: Options = {}): Plugin => {
         jsxFragment: options.jsxFragment || defaultOptions.jsxFragment,
         define: options.define,
         sourcemap: options.sourceMap,
-      }
+      } as Record<string, unknown>
 
       Object.keys(config).forEach(key => config[key] === undefined && delete config[key])
 


### PR DESCRIPTION
The latest version of esbuild throws an error when encountering undefined config properties. This code removes undefined properties before sending the config to esbuild