### PR TITLE
Fix source maps

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -131,7 +131,7 @@ export default (options: Options = {}): Plugin => {
         jsxFactory: options.jsxFactory || defaultOptions.jsxFactory,
         jsxFragment: options.jsxFragment || defaultOptions.jsxFragment,
         define: options.define,
-        sourcemap: options.sourceMap,
+        sourcemap: options.sourceMap !== false,
         sourcefile: id,
       })
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -132,6 +132,7 @@ export default (options: Options = {}): Plugin => {
         jsxFragment: options.jsxFragment || defaultOptions.jsxFragment,
         define: options.define,
         sourcemap: options.sourceMap,
+        sourcefile: id,
       })
 
       printWarnings(id, result, this)


### PR DESCRIPTION
- **fix: define `sourcefile` option for esbuild**
  This option must be defined when `sourcemap` is true. Otherwise an error is thrown.

- **fix: assume sourcemaps are wanted**
  When source maps are not generated by esbuild, the source maps generated by Rollup are incorrect.