### PR TITLE
fix: reuse `target` value while minifying

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -38,7 +38,7 @@ export type Options = {
 }
 
 export default (options: Options = {}): Plugin => {
-  let target: string | string[];
+  let target: string | string[]
 
   const loaders = {
     ...defaultLoaders,
@@ -128,7 +128,7 @@ export default (options: Options = {}): Plugin => {
           ? {}
           : await getOptions(dirname(id), options.tsconfig)
 
-      target = options.target || defaultOptions.target || 'es2017';
+      target = options.target || defaultOptions.target || 'es2017'
 
       const result = await service.transform(code, {
         loader,

--- a/src/index.ts
+++ b/src/index.ts
@@ -38,9 +38,12 @@ export type Options = {
 }
 
 export default (options: Options = {}): Plugin => {
+  let target: string | string[];
+
   const loaders = {
     ...defaultLoaders,
   }
+
   if (options.loaders) {
     for (const key of Object.keys(options.loaders)) {
       const value = options.loaders[key]
@@ -125,9 +128,11 @@ export default (options: Options = {}): Plugin => {
           ? {}
           : await getOptions(dirname(id), options.tsconfig)
 
+      target = options.target || defaultOptions.target || 'es2017';
+
       const result = await service.transform(code, {
         loader,
-        target: options.target || defaultOptions.target || 'es2017',
+        target,
         jsxFactory: options.jsxFactory || defaultOptions.jsxFactory,
         jsxFragment: options.jsxFragment || defaultOptions.jsxFragment,
         define: options.define,
@@ -150,6 +155,23 @@ export default (options: Options = {}): Plugin => {
       if (error && !this.meta.watchMode) {
         stopService()
       }
+    },
+
+    async renderChunk(code) {
+      if (options.minify && service) {
+        const result = await service.transform(code, {
+          loader: 'js',
+          minify: true,
+          target,
+        })
+        if (result.js) {
+          return {
+            code: result.js,
+            map: result.jsSourceMap || null,
+          }
+        }
+      }
+      return null
     },
 
     generateBundle() {

--- a/src/index.ts
+++ b/src/index.ts
@@ -152,23 +152,6 @@ export default (options: Options = {}): Plugin => {
       }
     },
 
-    async renderChunk(code) {
-      if (options.minify && service) {
-        const result = await service.transform(code, {
-          loader: 'js',
-          target: 'esnext',
-          minify: true,
-        })
-        if (result.js) {
-          return {
-            code: result.js,
-            map: result.jsSourceMap || null,
-          }
-        }
-      }
-      return null
-    },
-
     generateBundle() {
       if (!this.meta.watchMode) {
         stopService()


### PR DESCRIPTION
~Respect input options. Allow `esbuild` to minify during `transform` phase – it's certainly fast enough to handle it. 
Should that _not_ be the case, then user will decide & can set `options.minify: false` during `rollup -w` mode.~

Update: Overlooked the role of `renderChunk` here, oops. 
Instead, this now caches the `target` option value so that `renderChunk` and `transform` are producing the same version output. 

Closes #120