### PR TITLE
chore(docs): Add tsconfig option documentation to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ export default {
       define: {
         __VERSION__: '"x.y.z"'
       },
+      tsconfig: 'tsconfig.json', // default
       // Add extra loaders
       loaders: {
         // Add .json files support


### PR DESCRIPTION
Not sure if you are accepting PR's but noticed this was missing from readme when setting up earlier. I use different tsconfig path's so this option was ideal but found through source code search rather than readme.

Updated readme to reflect https://github.com/egoist/rollup-plugin-esbuild/commit/dc1b72e741703914f574a6b13219ce804f4b63f5