### PR TITLE
feat: Update to support esbuild v0.8.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "@types/jest": "^26.0.15",
     "@types/mock-fs": "^4.13.0",
     "@types/node": "14.14.3",
-    "esbuild": "^0.7.7",
+    "esbuild": "^0.8.0",
     "jest": "^26.6.1",
     "mock-fs": "^4.13.0",
     "prettier": "^2.1.2",
@@ -35,7 +35,7 @@
     "strip-json-comments": "^3.1.1"
   },
   "peerDependencies": {
-    "esbuild": "^0.6.0"
+    "esbuild": "^0.8.0"
   },
   "engines": {
     "node": ">=12"

--- a/src/index.ts
+++ b/src/index.ts
@@ -143,9 +143,9 @@ export default (options: Options = {}): Plugin => {
       printWarnings(id, result, this)
 
       return (
-        result.js && {
-          code: result.js,
-          map: result.jsSourceMap || null,
+        result.code && {
+          code: result.code,
+          map: result.map || null,
         }
       )
     },
@@ -164,10 +164,10 @@ export default (options: Options = {}): Plugin => {
           minify: true,
           target,
         })
-        if (result.js) {
+        if (result.code) {
           return {
-            code: result.js,
-            map: result.jsSourceMap || null,
+            code: result.code,
+            map: result.map || null,
           }
         }
       }

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -142,7 +142,7 @@ test('use custom jsxFactory (h) from tsconfig', async () => {
 
   const output = await build({}, { input: './fixture/index.jsx' })
   expect(output[0].code).toMatchInlineSnapshot(`
-    "const foo = /* @__PURE__ */ h(\\"div\\", null, \\"foo\\");
+    "const foo = /* @__PURE__ */ React.createElement(\\"div\\", null, \\"foo\\");
 
     export { foo };
     "

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -142,7 +142,7 @@ test('use custom jsxFactory (h) from tsconfig', async () => {
 
   const output = await build({}, { input: './fixture/index.jsx' })
   expect(output[0].code).toMatchInlineSnapshot(`
-    "const foo = /* @__PURE__ */ React.createElement(\\"div\\", null, \\"foo\\");
+    "const foo = /* @__PURE__ */ h(\\"div\\", null, \\"foo\\");
 
     export { foo };
     "

--- a/yarn.lock
+++ b/yarn.lock
@@ -1273,10 +1273,10 @@ error-ex@^1.3.1:
   dependencies:
     is-arrayish "^0.2.1"
 
-esbuild@^0.7.7:
-  version "0.7.7"
-  resolved "https://registry.yarnpkg.com/esbuild/-/esbuild-0.7.7.tgz#fd86332d1c0a047231bd6da930666028c40c14bf"
-  integrity sha512-1Ub4BBsWwPdxkwjyuXdKrgMIZROZ82ULIRFclOzXXVrqKOv9rMDoShRf23WEbPfeEA94z/BScKyUOyooyQ3XnQ==
+esbuild@^0.8.0:
+  version "0.8.0"
+  resolved "https://registry.yarnpkg.com/esbuild/-/esbuild-0.8.0.tgz#3173e851303dce0682ebbcbaf6072b991dd6f60e"
+  integrity sha512-xCHJpLRlU0NIANQHNsiMDNC/HlrKoye7iH5YOcoZNurauUZgMhjmm9PCal+Oo9ARYZrWxN15mykbfCX//UEvng==
 
 escape-string-regexp@^1.0.5:
   version "1.0.5"


### PR DESCRIPTION
As esbuild 0.8.0 had a breaking change to its API, changed its output from `output.js` and `output.jsSourceMap` to `output.code` and `output.map` respectively.




