### PR TITLE
Pair with `esbuild@^0.8` 

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "@types/jest": "^26.0.15",
     "@types/mock-fs": "^4.13.0",
     "@types/node": "14.14.3",
-    "esbuild": "^0.7.7",
+    "esbuild": "^0.8.0",
     "jest": "^26.6.1",
     "mock-fs": "^4.13.0",
     "prettier": "^2.1.2",
@@ -35,7 +35,7 @@
     "strip-json-comments": "^3.1.1"
   },
   "peerDependencies": {
-    "esbuild": "^0.6.0"
+    "esbuild": "^0.8.0"
   },
   "engines": {
     "node": ">=12"

--- a/src/index.ts
+++ b/src/index.ts
@@ -143,9 +143,9 @@ export default (options: Options = {}): Plugin => {
       printWarnings(id, result, this)
 
       return (
-        result.js && {
-          code: result.js,
-          map: result.jsSourceMap || null,
+        result.code && {
+          code: result.code,
+          map: result.map || null,
         }
       )
     },
@@ -164,10 +164,10 @@ export default (options: Options = {}): Plugin => {
           minify: true,
           target,
         })
-        if (result.js) {
+        if (result.code) {
           return {
-            code: result.js,
-            map: result.jsSourceMap || null,
+            code: result.code,
+            map: result.map || null,
           }
         }
       }


### PR DESCRIPTION
esbuild had a significant [`0.8.0` release](https://github.com/evanw/esbuild/blob/05e64d6fe357ae52b488293f4dd1ec9f164b9093/CHANGELOG.md#080)

It's a breaking change with its `transform` output. It aligns with what Rollup expects, but I kept the conditional checks in place so that we're still omitting the `warnings` field.

Bumped the peer dependency requirement too, so that new `npm`/package managers won't auto-install `esbuild@0.6.0` _in addition to_ the `esbuild@0.8.0` (or 0.7) dependency that the developer declared manually.

If it were me, I'd release this as a 3.0 to be safe.