### PR TITLE
Upgrade to esbuild 0.9

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "@types/jest": "^26.0.20",
     "@types/mock-fs": "^4.13.0",
     "@types/node": "14.14.32",
-    "esbuild": "^0.8.0",
+    "esbuild": "^0.9.0",
     "jest": "^26.6.3",
     "mock-fs": "^4.13.0",
     "prettier": "^2.2.1",
@@ -35,7 +35,7 @@
     "strip-json-comments": "^3.1.1"
   },
   "peerDependencies": {
-    "esbuild": ">=0.7.0"
+    "esbuild": ">=0.9.0"
   },
   "engines": {
     "node": ">=12"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1275,10 +1275,10 @@ error-ex@^1.3.1:
   dependencies:
     is-arrayish "^0.2.1"
 
-esbuild@^0.8.0:
-  version "0.8.0"
-  resolved "https://registry.yarnpkg.com/esbuild/-/esbuild-0.8.0.tgz#3173e851303dce0682ebbcbaf6072b991dd6f60e"
-  integrity sha512-xCHJpLRlU0NIANQHNsiMDNC/HlrKoye7iH5YOcoZNurauUZgMhjmm9PCal+Oo9ARYZrWxN15mykbfCX//UEvng==
+esbuild@^0.9.0:
+  version "0.9.0"
+  resolved "https://registry.yarnpkg.com/esbuild/-/esbuild-0.9.0.tgz#b8320df85048ed1637c6b59ee52abba248936d3c"
+  integrity sha512-IqYFO7ZKHf0y4uJpJfGqInmSRn8jMPMbyI1W0Y2PSjSjJcVP538tC8TleJAS4Y8QeqwajqBTwFKayWVzYlMIgg==
 
 escape-string-regexp@^1.0.5:
   version "1.0.5"


### PR DESCRIPTION
fix: #209 

Recently esbuild 0.9 was released with some breaking changes. And one of the breaking changes broke this plugin: which is the removal of `esbuild.startService` function.

This commit change peer and `devDependencies` to esbuild 0.9 and also removing usage of service in the plugin. Instead it use `transform` function directly.

All tests passed and the example is bundled just fine.