### PR TITLE
chore: add rollup as peerDependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,8 @@
     "jsonc-parser": "^3.0.0"
   },
   "peerDependencies": {
-    "esbuild": ">=0.9.0"
+    "esbuild": ">=0.9.0",
+    "rollup": "^1.20.0 || ^2.0.0"
   },
   "engines": {
     "node": ">=12"


### PR DESCRIPTION
This prevents a warning from yarn 2, for example.