### PR TITLE
feat: export minify function as a standalone plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,18 @@ export default {
 }
 ```
 
+### Standalone Minify Plugin
+
+If you only want to use this plugin to minify your bundle:
+
+```js
+import { minify } from 'rollup-plugin-esbuild'
+
+export default {
+  plugins: [minify()],
+}
+```
+
 ### Bundle mode
 
 This plugin also includes an experimental `bundle` mode which lets rollup `resolve`, `load`, and `transform` imported files but leaves bundling to esbuild. In my simple test it's around 50% faster than non-bundle mode, but still 10x slower than raw esbuild.
@@ -92,7 +104,6 @@ Current limitation: no code splitting yet.
 ## Sponsors
 
 [![sponsors](https://sponsors-images.egoist.sh/sponsors.svg)](https://github.com/sponsors/egoist)
-
 
 ## License
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,18 +1,14 @@
 import { existsSync, statSync } from 'fs'
 import { extname, resolve, dirname, join } from 'path'
 import { Plugin } from 'rollup'
-import {
-  transform,
-  Loader,
-  CommonOptions,
-} from 'esbuild'
+import { transform, Loader, CommonOptions } from 'esbuild'
 import { createFilter, FilterPattern } from '@rollup/pluginutils'
 import { getOptions } from './options'
 import { bundle } from './bundle'
-import { getRenderChunk } from './minify';
-import { warn } from './warn';
+import { minify, getRenderChunk } from './minify'
+import { warn } from './warn'
 
-export { default as minify } from './minify';
+export { minify }
 
 const defaultLoaders: { [ext: string]: Loader } = {
   '.js': 'js',

--- a/src/minify.ts
+++ b/src/minify.ts
@@ -1,17 +1,15 @@
 import { Plugin, InternalModuleFormat, RenderChunkHook } from 'rollup'
-import {
-  transform,
-  CommonOptions,
-  Format,
-} from 'esbuild'
+import { transform, CommonOptions, Format } from 'esbuild'
 import { warn } from './warn'
 
-const getEsbuildFormat = (rollupFormat: InternalModuleFormat): Format | undefined => {
+const getEsbuildFormat = (
+  rollupFormat: InternalModuleFormat
+): Format | undefined => {
   if (rollupFormat === 'es') {
-    return 'esm';
+    return 'esm'
   }
   if (rollupFormat === 'cjs' || rollupFormat === 'iife') {
-    return rollupFormat;
+    return rollupFormat
   }
 }
 
@@ -25,43 +23,44 @@ export type Options = {
   legalComments?: CommonOptions['legalComments']
 }
 
-export const getRenderChunk = (options: Options): RenderChunkHook => async function (code, _, rollupOptions) {
-	if (
-        options.minify ||
-        options.minifyWhitespace ||
-        options.minifyIdentifiers ||
-        options.minifySyntax
-      ) {
-        const format = getEsbuildFormat(rollupOptions.format);
-        const result = await transform(code, {
-          format,
-          loader: 'js',
-          minify: options.minify,
-          minifyWhitespace: options.minifyWhitespace,
-          minifyIdentifiers: options.minifyIdentifiers,
-          minifySyntax: options.minifySyntax,
-		  keepNames: options.keepNames,
-		  legalComments: options.legalComments,
-          sourcemap: options.sourceMap !== false,
-        })
-        await warn(this, result.warnings)
-        if (result.code) {
-          return {
-            code: result.code,
-            map: result.map || null,
-          }
+export const getRenderChunk = (options: Options): RenderChunkHook =>
+  async function (code, _, rollupOptions) {
+    if (
+      options.minify ||
+      options.minifyWhitespace ||
+      options.minifyIdentifiers ||
+      options.minifySyntax
+    ) {
+      const format = getEsbuildFormat(rollupOptions.format)
+      const result = await transform(code, {
+        format,
+        loader: 'js',
+        minify: options.minify,
+        minifyWhitespace: options.minifyWhitespace,
+        minifyIdentifiers: options.minifyIdentifiers,
+        minifySyntax: options.minifySyntax,
+        keepNames: options.keepNames,
+        legalComments: options.legalComments,
+        sourcemap: options.sourceMap !== false,
+      })
+      await warn(this, result.warnings)
+      if (result.code) {
+        return {
+          code: result.code,
+          map: result.map || null,
         }
       }
-      return null
-}
+    }
+    return null
+  }
 
-export default (options: Options = {}): Plugin => {
+export const minify = (options: Options = {}): Plugin => {
   return {
     name: 'esbuild-minify',
 
     renderChunk: getRenderChunk({
-		minify: true,
-		...options,
-	}),
+      minify: true,
+      ...options,
+    }),
   }
 }

--- a/src/minify.ts
+++ b/src/minify.ts
@@ -1,0 +1,67 @@
+import { Plugin, InternalModuleFormat, RenderChunkHook } from 'rollup'
+import {
+  transform,
+  CommonOptions,
+  Format,
+} from 'esbuild'
+import { warn } from './warn'
+
+const getEsbuildFormat = (rollupFormat: InternalModuleFormat): Format | undefined => {
+  if (rollupFormat === 'es') {
+    return 'esm';
+  }
+  if (rollupFormat === 'cjs' || rollupFormat === 'iife') {
+    return rollupFormat;
+  }
+}
+
+export type Options = {
+  sourceMap?: boolean
+  minify?: boolean
+  minifyWhitespace?: boolean
+  minifyIdentifiers?: boolean
+  minifySyntax?: boolean
+  keepNames?: boolean
+  legalComments?: CommonOptions['legalComments']
+}
+
+export const getRenderChunk = (options: Options): RenderChunkHook => async function (code, _, rollupOptions) {
+	if (
+        options.minify ||
+        options.minifyWhitespace ||
+        options.minifyIdentifiers ||
+        options.minifySyntax
+      ) {
+        const format = getEsbuildFormat(rollupOptions.format);
+        const result = await transform(code, {
+          format,
+          loader: 'js',
+          minify: options.minify,
+          minifyWhitespace: options.minifyWhitespace,
+          minifyIdentifiers: options.minifyIdentifiers,
+          minifySyntax: options.minifySyntax,
+		  keepNames: options.keepNames,
+		  legalComments: options.legalComments,
+          sourcemap: options.sourceMap !== false,
+        })
+        await warn(this, result.warnings)
+        if (result.code) {
+          return {
+            code: result.code,
+            map: result.map || null,
+          }
+        }
+      }
+      return null
+}
+
+export default (options: Options = {}): Plugin => {
+  return {
+    name: 'esbuild-minify',
+
+    renderChunk: getRenderChunk({
+		minify: true,
+		...options,
+	}),
+  }
+}

--- a/src/warn.ts
+++ b/src/warn.ts
@@ -1,0 +1,15 @@
+import { PluginContext } from 'rollup'
+import {
+	formatMessages,
+	Message,
+} from 'esbuild'
+
+export const warn = async (pluginContext: PluginContext, messages: Message[]) => {
+	if (messages.length > 0) {
+		const warnings = await formatMessages(messages, {
+		kind: 'warning',
+		color: true,
+		})
+		warnings.forEach((warning) => pluginContext.warn(warning))
+	}
+}

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -1,7 +1,7 @@
 import path from 'path'
 import fs from 'fs'
 import { rollup, Plugin as RollupPlugin, ModuleFormat } from 'rollup'
-import esbuild, { Options } from '../src'
+import esbuild, { minify } from '../src'
 
 const realFs = (folderName: string, files: Record<string, string>) => {
   const tmpDir = path.join(__dirname, '.temp', `esbuild/${folderName}`)
@@ -15,324 +15,388 @@ const realFs = (folderName: string, files: Record<string, string>) => {
 
 const getTestName = () => expect.getState().currentTestName
 
-const build = async (
-  options?: Options,
-  {
-    input = './fixture/index.js',
-    sourcemap = false,
-    rollupPlugins = [],
-    dir = '.',
-    format = 'esm',
-  }: {
-    input?: string | string[]
-    sourcemap?: boolean
-    rollupPlugins?: RollupPlugin[]
-    dir?: string
-    format?: ModuleFormat
-  } = {}
-) => {
+const build = async ({
+  input = './fixture/index.js',
+  sourcemap = false,
+  rollupPlugins = [],
+  dir = '.',
+  format = 'esm',
+}: {
+  input?: string | string[]
+  sourcemap?: boolean
+  rollupPlugins?: RollupPlugin[]
+  dir?: string
+  format?: ModuleFormat
+} = {}) => {
   const build = await rollup({
     input: [...(Array.isArray(input) ? input : [input])].map((v) =>
       path.resolve(dir, v)
     ),
-    plugins: [esbuild(options), ...rollupPlugins],
+    plugins: rollupPlugins,
   })
-  const { output } = await build.generate({ format, sourcemap })
+  const { output } = await build.generate({
+    format,
+    sourcemap,
+    exports: 'auto',
+  })
   return output
 }
 
-test('simple', async () => {
-  const dir = realFs(getTestName(), {
-    './fixture/index.js': `
-      import Foo from './foo'
-
-      console.log(Foo)
-    `,
-    './fixture/foo.tsx': `
-      export default class Foo {
-        render() {
-          return <div className="hehe">hello there!!!</div>
+describe('esbuild plugin', () => {
+  test('simple', async () => {
+    const dir = realFs(getTestName(), {
+      './fixture/index.js': `
+        import Foo from './foo'
+  
+        console.log(Foo)
+      `,
+      './fixture/foo.tsx': `
+        export default class Foo {
+          render() {
+            return <div className="hehe">hello there!!!</div>
+          }
         }
-      }
-    `,
-  })
-  const output = await build({}, { dir })
-  expect(output[0].code).toMatchInlineSnapshot(`
-    "class Foo {
-      render() {
-        return /* @__PURE__ */ React.createElement(\\"div\\", {
-          className: \\"hehe\\"
-        }, \\"hello there!!!\\");
-      }
-    }
-
-    console.log(Foo);
-    "
-  `)
-})
-
-test('minify', async () => {
-  const dir = realFs(getTestName(), {
-    './fixture/index.js': `
-      import Foo from './foo'
-
-      console.log(Foo)
-    `,
-    './fixture/foo.tsx': `
-      export default class Foo {
-        render() {
-          return <div className="hehe">hello there!!!</div>
-        }
-      }
-    `,
-  })
-  const output = await build({ minify: true }, { dir })
-  expect(output[0].code).toMatchInlineSnapshot(`
-    "class e{render(){return React.createElement(\\"div\\",{className:\\"hehe\\"},\\"hello there!!!\\")}}console.log(e);
-    "
-  `)
-})
-
-test('keepNames', async () => {
-  const dir = realFs(getTestName(), {
-    './fixture/index.js': `
-      export default class Foo {}
-    `,
-  })
-  const output = await build({ minify: true, keepNames: true }, { dir })
-  expect(output[0].code).toMatchInlineSnapshot(`
-    "var r=Object.defineProperty,t=(e,o)=>r(e,\\"name\\",{value:o,configurable:!0});class a{}t(a,\\"Foo\\");export{a as default};
-    "
-  `)
-})
-
-test('minify whitespace only', async () => {
-  const dir = realFs(getTestName(), {
-    './fixture/index.js': `
-      console.log(1 === 1);
-    `,
-  })
-  const output = await build({ minifyWhitespace: true }, { dir })
-  expect(output[0].code).toMatchInlineSnapshot(`
-    "console.log(true);
-    "
-  `)
-})
-
-test('minify syntax only', async () => {
-  const dir = realFs(getTestName(), {
-    './fixture/index.js': `
-      console.log(1 === 1);
-    `,
-  })
-  const output = await build({ minifySyntax: true }, { dir })
-  expect(output[0].code).toMatchInlineSnapshot(`
-    "console.log(!0);
-    "
-  `)
-})
-
-test('minify cjs', async () => {
-  const dir = realFs(getTestName(), {
-    './fixture/index.js': `
-		const minifyMe = true
-		console.log(minifyMe);
-	  `,
-  })
-  const output = await build(
-    { minify: true },
-    {
+      `,
+    })
+    const output = await build({
       dir,
+      rollupPlugins: [esbuild({})],
+    })
+    expect(output[0].code).toMatchInlineSnapshot(`
+      "class Foo {
+        render() {
+          return /* @__PURE__ */ React.createElement(\\"div\\", {
+            className: \\"hehe\\"
+          }, \\"hello there!!!\\");
+        }
+      }
+
+      console.log(Foo);
+      "
+    `)
+  })
+
+  test('minify', async () => {
+    const dir = realFs(getTestName(), {
+      './fixture/index.js': `
+        import Foo from './foo'
+  
+        console.log(Foo)
+      `,
+      './fixture/foo.tsx': `
+        export default class Foo {
+          render() {
+            return <div className="hehe">hello there!!!</div>
+          }
+        }
+      `,
+    })
+    const output = await build({
+      dir,
+      rollupPlugins: [esbuild({ minify: true })],
+    })
+    expect(output[0].code).toMatchInlineSnapshot(`
+      "class e{render(){return React.createElement(\\"div\\",{className:\\"hehe\\"},\\"hello there!!!\\")}}console.log(e);
+      "
+    `)
+  })
+
+  test('keepNames', async () => {
+    const dir = realFs(getTestName(), {
+      './fixture/index.js': `
+        export default class Foo {}
+      `,
+    })
+    const output = await build({
+      dir,
+      rollupPlugins: [esbuild({ minify: true, keepNames: true })],
+      format: 'cjs',
+    })
+    expect(eval(output[0].code).name).toBe('Foo')
+    expect(output[0].code).toMatchInlineSnapshot(`
+      "\\"use strict\\";var r=Object.defineProperty;var t=(s,e)=>r(s,\\"name\\",{value:e,configurable:!0});class c{}t(c,\\"Foo\\"),module.exports=c;
+      "
+    `)
+  })
+
+  test('minify whitespace only', async () => {
+    const dir = realFs(getTestName(), {
+      './fixture/index.js': `
+        console.log(1 === 1);
+      `,
+    })
+    const output = await build({
+      dir,
+      rollupPlugins: [esbuild({ minifyWhitespace: true })],
+    })
+    expect(output[0].code).toMatchInlineSnapshot(`
+      "console.log(true);
+      "
+    `)
+  })
+
+  test('minify syntax only', async () => {
+    const dir = realFs(getTestName(), {
+      './fixture/index.js': `
+        console.log(1 === 1);
+      `,
+    })
+    const output = await build({
+      dir,
+      rollupPlugins: [esbuild({ minifySyntax: true })],
+    })
+    expect(output[0].code).toMatchInlineSnapshot(`
+      "console.log(!0);
+      "
+    `)
+  })
+
+  test('minify cjs', async () => {
+    const dir = realFs(getTestName(), {
+      './fixture/index.js': `
+      const minifyMe = true
+      console.log(minifyMe);
+      `,
+    })
+    const output = await build({
+      dir,
+      rollupPlugins: [esbuild({ minify: true })],
       format: 'commonjs',
-    }
-  )
-  expect(output[0].code).toMatchInlineSnapshot(`
-    "\\"use strict\\";const e=!0;console.log(e);
-    "
-  `)
-})
-
-test('minify iife', async () => {
-  const dir = realFs(getTestName(), {
-    './fixture/index.js': `
-		const minifyMe = true
-		console.log(minifyMe);
-	  `,
+    })
+    expect(output[0].code).toMatchInlineSnapshot(`
+      "\\"use strict\\";const e=!0;console.log(e);
+      "
+    `)
   })
-  const output = await build(
-    { minify: true },
-    {
+
+  test('minify iife', async () => {
+    const dir = realFs(getTestName(), {
+      './fixture/index.js': `
+      const minifyMe = true
+      console.log(minifyMe);
+      `,
+    })
+    const output = await build({
       dir,
+      rollupPlugins: [esbuild({ minify: true })],
       format: 'iife',
-    }
-  )
-  expect(output[0].code).toMatchInlineSnapshot(`
-    "(()=>{(function(){\\"use strict\\";console.log(!0)})();})();
-    "
-  `)
-})
-
-test('minify umd', async () => {
-  const dir = realFs(getTestName(), {
-    './fixture/index.js': `
-		const minifyMe = true
-		console.log(minifyMe);
-	  `,
+    })
+    expect(output[0].code).toMatchInlineSnapshot(`
+      "(()=>{(function(){\\"use strict\\";console.log(!0)})();})();
+      "
+    `)
   })
-  const output = await build(
-    { minify: true },
-    {
+
+  test('minify umd', async () => {
+    const dir = realFs(getTestName(), {
+      './fixture/index.js': `
+      const minifyMe = true
+      console.log(minifyMe);
+      `,
+    })
+    const output = await build({
       dir,
+      rollupPlugins: [esbuild({ minify: true })],
       format: 'umd',
-    }
-  )
-  expect(output[0].code).toMatchInlineSnapshot(`
-    "(function(n){typeof define==\\"function\\"&&define.amd?define(n):n()})(function(){\\"use strict\\";console.log(!0)});
-    "
-  `)
-})
-
-test('legal comments none', async () => {
-  const dir = realFs(getTestName(), {
-    './fixture/index.js': `/** @preserve comment */
-      /*!
-       * comment
-       */
-      //! comment
-      console.log(1 === 1);
-    `,
+    })
+    expect(output[0].code).toMatchInlineSnapshot(`
+      "(function(n){typeof define==\\"function\\"&&define.amd?define(n):n()})(function(){\\"use strict\\";console.log(!0)});
+      "
+    `)
   })
-  const output = await build({ minify: true, legalComments: 'none' }, { dir })
-  expect(output[0].code).toMatchInlineSnapshot(`
-    "console.log(!0);
-    "
-  `)
-})
 
-test('load index.(x)', async () => {
-  const dir = realFs(getTestName(), {
-    './fixture/index.js': `
-      import Foo from './foo'
+  test('legal comments none', async () => {
+    const dir = realFs(getTestName(), {
+      './fixture/index.js': `/** @preserve comment */
+        /*!
+         * comment
+         */
+        //! comment
+        console.log(1 === 1);
+      `,
+    })
+    const output = await build({
+      dir,
+      rollupPlugins: [esbuild({ minify: true, legalComments: 'none' })],
+    })
+    expect(output[0].code).toMatchInlineSnapshot(`
+      "console.log(!0);
+      "
+    `)
+  })
 
-      console.log(Foo)
-    `,
-    './fixture/foo/index.tsx': `
-      export default class Foo {
+  test('load index.(x)', async () => {
+    const dir = realFs(getTestName(), {
+      './fixture/index.js': `
+        import Foo from './foo'
+  
+        console.log(Foo)
+      `,
+      './fixture/foo/index.tsx': `
+        export default class Foo {
+          render() {
+            return <div className="hehe">hello there!!!</div>
+          }
+        }
+      `,
+    })
+
+    const output = await build({
+      dir,
+      rollupPlugins: [esbuild({})],
+    })
+    expect(output[0].code).toMatchInlineSnapshot(`
+      "class Foo {
         render() {
-          return <div className="hehe">hello there!!!</div>
+          return /* @__PURE__ */ React.createElement(\\"div\\", {
+            className: \\"hehe\\"
+          }, \\"hello there!!!\\");
         }
       }
-    `,
+
+      console.log(Foo);
+      "
+    `)
   })
 
-  const output = await build({}, { dir })
-  expect(output[0].code).toMatchInlineSnapshot(`
-    "class Foo {
-      render() {
-        return /* @__PURE__ */ React.createElement(\\"div\\", {
-          className: \\"hehe\\"
-        }, \\"hello there!!!\\");
-      }
-    }
+  test('load json', async () => {
+    const dir = realFs(getTestName(), {
+      './fixture/index.js': `
+        import * as foo from './foo'
+  
+        console.log(foo)
+      `,
+      './fixture/foo.json': `
+        {
+          "foo": true
+        }
+      `,
+    })
 
-    console.log(Foo);
-    "
-  `)
+    const output = await build({
+      dir,
+      rollupPlugins: [
+        esbuild({
+          loaders: {
+            '.json': 'json',
+          },
+        }),
+      ],
+    })
+    // Following code is expected
+    // esbuild doesn't emit json code as es module for now
+    // So you will need @rollup/plugin-commonjs
+    expect(output[0].code).toMatchInlineSnapshot(`
+      "module.exports = {
+        foo: true
+      };
+
+      var foo = /*#__PURE__*/Object.freeze({
+            __proto__: null
+      });
+
+      console.log(foo);
+      "
+    `)
+  })
+
+  test('use custom jsxFactory (h) from tsconfig', async () => {
+    const dir = realFs(getTestName(), {
+      './fixture/index.jsx': `
+        export const foo = <div>foo</div>
+      `,
+      './fixture/tsconfig.json': `
+        {
+          "compilerOptions": {
+            "jsxFactory": "h"
+          }
+        }
+      `,
+    })
+
+    const output = await build({
+      input: './fixture/index.jsx',
+      dir,
+      rollupPlugins: [esbuild({})],
+    })
+    expect(output[0].code).toMatchInlineSnapshot(`
+      "const foo = /* @__PURE__ */ h(\\"div\\", null, \\"foo\\");
+
+      export { foo };
+      "
+    `)
+  })
+
+  test('use custom tsconfig.json', async () => {
+    const dir = realFs(getTestName(), {
+      './fixture/index.jsx': `
+        export const foo = <div>foo</div>
+      `,
+      './fixture/tsconfig.json': `
+        {
+          "compilerOptions": {
+            "jsxFactory": "h"
+          }
+        }
+      `,
+      './fixture/tsconfig.build.json': `
+        {
+          "compilerOptions": {
+            "jsxFactory": "custom"
+          }
+        }
+      `,
+    })
+
+    const output = await build({
+      input: './fixture/index.jsx',
+      dir,
+      rollupPlugins: [esbuild({ tsconfig: 'tsconfig.build.json' })],
+    })
+    expect(output[0].code).toMatchInlineSnapshot(`
+      "const foo = /* @__PURE__ */ custom(\\"div\\", null, \\"foo\\");
+
+      export { foo };
+      "
+    `)
+  })
 })
 
-test('load json', async () => {
-  const dir = realFs(getTestName(), {
-    './fixture/index.js': `
-      import * as foo from './foo'
-
-      console.log(foo)
-    `,
-    './fixture/foo.json': `
-      {
-        "foo": true
-      }
-    `,
+describe('minify plugin', () => {
+  test('minify esm', async () => {
+    const dir = realFs(getTestName(), {
+      './fixture/index.js': `
+      const minifyMe = true
+      console.log(minifyMe);
+      `,
+    })
+    const output = await build({
+      dir,
+      rollupPlugins: [minify()],
+    })
+    expect(output[0].code).toMatchInlineSnapshot(`
+      "const o=!0;console.log(o);
+      "
+    `)
   })
 
-  const output = await build(
-    {
-      loaders: {
-        '.json': 'json',
-      },
-    },
-    { dir }
-  )
-  // Following code is expected
-  // esbuild doesn't emit json code as es module for now
-  // So you will need @rollup/plugin-commonjs
-  expect(output[0].code).toMatchInlineSnapshot(`
-    "module.exports = {
-      foo: true
-    };
-
-    var foo = /*#__PURE__*/Object.freeze({
-        __proto__: null
-    });
-
-    console.log(foo);
-    "
-  `)
-})
-
-test('use custom jsxFactory (h) from tsconfig', async () => {
-  const dir = realFs(getTestName(), {
-    './fixture/index.jsx': `
-      export const foo = <div>foo</div>
-    `,
-    './fixture/tsconfig.json': `
-      {
-        "compilerOptions": {
-          "jsxFactory": "h"
-        }
-      }
-    `,
+  test('minify cjs', async () => {
+    const dir = realFs(getTestName(), {
+      './fixture/index.js': `
+      const minifyMe = true
+      console.log(minifyMe);
+      `,
+    })
+    const output = await build({
+      dir,
+      rollupPlugins: [minify()],
+      format: 'commonjs',
+    })
+    expect(output[0].code).toMatchInlineSnapshot(`
+      "\\"use strict\\";const e=!0;console.log(e);
+      "
+    `)
   })
-
-  const output = await build({}, { input: './fixture/index.jsx', dir })
-  expect(output[0].code).toMatchInlineSnapshot(`
-    "const foo = /* @__PURE__ */ h(\\"div\\", null, \\"foo\\");
-
-    export { foo };
-    "
-  `)
-})
-
-test('use custom tsconfig.json', async () => {
-  const dir = realFs(getTestName(), {
-    './fixture/index.jsx': `
-      export const foo = <div>foo</div>
-    `,
-    './fixture/tsconfig.json': `
-      {
-        "compilerOptions": {
-          "jsxFactory": "h"
-        }
-      }
-    `,
-    './fixture/tsconfig.build.json': `
-      {
-        "compilerOptions": {
-          "jsxFactory": "custom"
-        }
-      }
-    `,
-  })
-
-  const output = await build(
-    { tsconfig: 'tsconfig.build.json' },
-    { input: './fixture/index.jsx', dir }
-  )
-  expect(output[0].code).toMatchInlineSnapshot(`
-    "const foo = /* @__PURE__ */ custom(\\"div\\", null, \\"foo\\");
-
-    export { foo };
-    "
-  `)
 })
 
 describe('bundle', () => {
@@ -352,25 +416,23 @@ describe('bundle', () => {
       export const B = () => <Foo>B</Foo>
       `,
     })
-    const output = await build(
-      { experimentalBundling: true },
-      {
-        input: [
-          path.join(dir, './fixture/entry-a.jsx'),
-          path.join(dir, './fixture/entry-b.jsx'),
-        ],
-        rollupPlugins: [
-          {
-            name: 'alias',
-            resolveId(source, importer) {
-              if (source === 'bar' && importer) {
-                return path.join(path.dirname(importer), 'bar.ts')
-              }
-            },
+    const output = await build({
+      input: [
+        path.join(dir, './fixture/entry-a.jsx'),
+        path.join(dir, './fixture/entry-b.jsx'),
+      ],
+      rollupPlugins: [
+        esbuild({ experimentalBundling: true }),
+        {
+          name: 'alias',
+          resolveId(source, importer) {
+            if (source === 'bar' && importer) {
+              return path.join(path.dirname(importer), 'bar.ts')
+            }
           },
-        ],
-      }
-    )
+        },
+      ],
+    })
     expect(
       output.map((o) => {
         return {


### PR DESCRIPTION
closes https://github.com/egoist/rollup-plugin-esbuild/issues/310

Since this happens post-bundling, it didn't make sense to add `include`/`exclude`