### PR TITLE
fix: support mapping .js/.jsx extensions to .ts/.tsx

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -23,7 +23,7 @@ jobs:
 
       - uses: actions/setup-node@v1
         with:
-          node-version: 14.x
+          node-version: 16.x
 
       - name: Cache ~/.pnpm-store
         uses: actions/cache@v2
@@ -47,7 +47,7 @@ jobs:
         run: npm run test
 
       - name: Release
-        run: pnpx -y semantic-release
+        run: pnpx semantic-release
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,4 +1,4 @@
-lockfileVersion: 5.3
+lockfileVersion: 5.4
 
 specifiers:
   '@rollup/plugin-commonjs': ^21.0.1
@@ -47,7 +47,7 @@ devDependencies:
   rollup: 2.59.0
   three: 0.136.0
   ts-essentials: 9.1.0_typescript@4.4.4
-  ts-jest: 27.0.7_2c4ca6574207836d1023f54689cc81ac
+  ts-jest: 27.0.7_frgkmv2ca6bw2ebd6vdittebvq
   tsup: 5.7.2_typescript@4.4.4
   typescript: 4.4.4
   vue: 3.2.26
@@ -236,12 +236,16 @@ packages:
     resolution: {integrity: sha512-RUVpT0G2h6rOZwqLDTrKk7ksNv7YpAilTnYe1/Q+eDjxEceRMKVWbCsX7t8h6C1qCFi/1Y8WZjcEPBAFG27GPw==}
     engines: {node: '>=6.0.0'}
     hasBin: true
+    dependencies:
+      '@babel/types': 7.16.0
     dev: true
 
   /@babel/parser/7.16.6:
     resolution: {integrity: sha512-Gr86ujcNuPDnNOY8mi383Hvi8IYrJVJYuf3XcuBM/Dgd+bINn/7tHqsj+tKkoreMbmGsFLsltI/JJd8fOFWGDQ==}
     engines: {node: '>=6.0.0'}
     hasBin: true
+    dependencies:
+      '@babel/types': 7.16.0
     dev: true
 
   /@babel/plugin-syntax-async-generators/7.8.4_@babel+core@7.16.0:
@@ -3374,7 +3378,7 @@ packages:
     resolution: {integrity: sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==}
     dev: true
 
-  /ts-jest/27.0.7_2c4ca6574207836d1023f54689cc81ac:
+  /ts-jest/27.0.7_frgkmv2ca6bw2ebd6vdittebvq:
     resolution: {integrity: sha512-O41shibMqzdafpuP+CkrOL7ykbmLh+FqQrXEmV9CydQ5JBk0Sj0uAEF5TNNe94fZWKm3yYvWa/IbyV4Yg1zK2Q==}
     engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
     hasBin: true

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,5 @@
 import { existsSync, statSync } from 'fs'
-import { extname, resolve, dirname, join } from 'path'
+import { extname, resolve, dirname, join, basename } from 'path'
 import { Plugin as RollupPlugin } from 'rollup'
 import { transform, Loader, TransformOptions } from 'esbuild'
 import { MarkOptional } from 'ts-essentials'
@@ -83,8 +83,9 @@ export default ({
   )
 
   const resolveFile = (resolved: string, index: boolean = false) => {
+    const fileWithoutExt = join(dirname(resolved), basename(resolved, extname(resolved)))
     for (const ext of extensions) {
-      const file = index ? join(resolved, `index${ext}`) : `${resolved}${ext}`
+      const file = index ? join(resolved, `index${ext}`) : `${fileWithoutExt}${ext}`
       if (existsSync(file)) return file
     }
     return null

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -182,7 +182,7 @@ describe('esbuild plugin', () => {
       format: 'commonjs',
     })
     expect(output[0].code).toMatchInlineSnapshot(`
-      "\\"use strict\\";Object.defineProperty(exports,\\"__esModule\\",{value:!0});const e=!0;console.log(e),exports.minifyMe=e;
+      "\\"use strict\\";Object.defineProperty(exports,\\"__esModule\\",{value:!0});const e=!0;console.log(!0),exports.minifyMe=e;
       "
     `)
   })
@@ -251,6 +251,40 @@ describe('esbuild plugin', () => {
         console.log(Foo)
       `,
       './fixture/foo/index.tsx': `
+        export default class Foo {
+          render() {
+            return <div className="hehe">hello there!!!</div>
+          }
+        }
+      `,
+    })
+
+    const output = await build({
+      dir,
+      rollupPlugins: [esbuild({})],
+    })
+    expect(output[0].code).toMatchInlineSnapshot(`
+      "class Foo {
+        render() {
+          return /* @__PURE__ */ React.createElement(\\"div\\", {
+            className: \\"hehe\\"
+          }, \\"hello there!!!\\");
+        }
+      }
+
+      console.log(Foo);
+      "
+    `)
+  })
+
+  test('load jsx/tsx', async () => {
+    const dir = realFs(getTestName(), {
+      './fixture/index.js': `
+        import Foo from './foo.jsx'
+  
+        console.log(Foo)
+      `,
+      './fixture/foo.tsx': `
         export default class Foo {
           render() {
             return <div className="hehe">hello there!!!</div>
@@ -393,7 +427,7 @@ describe('minify plugin', () => {
       rollupPlugins: [minify()],
     })
     expect(output[0].code).toMatchInlineSnapshot(`
-      "const o=!0;console.log(o);
+      "const e=!0;console.log(!0);
       "
     `)
   })
@@ -411,7 +445,7 @@ describe('minify plugin', () => {
       format: 'commonjs',
     })
     expect(output[0].code).toMatchInlineSnapshot(`
-      "\\"use strict\\";const e=!0;console.log(e);
+      "\\"use strict\\";const e=!0;console.log(!0);
       "
     `)
   })

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -182,7 +182,7 @@ describe('esbuild plugin', () => {
       format: 'commonjs',
     })
     expect(output[0].code).toMatchInlineSnapshot(`
-      "\\"use strict\\";Object.defineProperty(exports,\\"__esModule\\",{value:!0});const e=!0;console.log(!0),exports.minifyMe=e;
+      "\\"use strict\\";Object.defineProperty(exports,\\"__esModule\\",{value:!0});const e=!0;console.log(e),exports.minifyMe=e;
       "
     `)
   })
@@ -427,7 +427,7 @@ describe('minify plugin', () => {
       rollupPlugins: [minify()],
     })
     expect(output[0].code).toMatchInlineSnapshot(`
-      "const e=!0;console.log(!0);
+      "const o=!0;console.log(o);
       "
     `)
   })
@@ -445,7 +445,7 @@ describe('minify plugin', () => {
       format: 'commonjs',
     })
     expect(output[0].code).toMatchInlineSnapshot(`
-      "\\"use strict\\";const e=!0;console.log(!0);
+      "\\"use strict\\";const e=!0;console.log(e);
       "
     `)
   })


### PR DESCRIPTION
When using native ESM, extensions like `.js` or `.jsx` are required for `TypeScript` with `"moduleResolution": "Node16"`.

For example: `export * from './component.jsx'` should try `'./component.tsx'`, this PR just drop the file extension and try all possible extensions, if you want behavior more spec compliantly, `resolveFile` must be refactored a lot AFAIK.

Considering `.tsx` can also be compiled as `.js`, I think this PR's behavior is good enough.

cc @egoist 