### PR TITLE
fix: fix sourcemap behavior

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ export default {
       // All options are optional
       include: /\.[jt]sx?$/, // default, inferred from `loaders` option
       exclude: /node_modules/, // default
-      sourceMap: false, // by default inferred from rollup's `output.sourcemap` option
+      sourceMap: true, // default
       minify: process.env.NODE_ENV === 'production',
       target: 'es2017', // default, or 'es20XX', 'esnext'
       jsx: 'transform', // default, or 'preserve'

--- a/src/index.ts
+++ b/src/index.ts
@@ -50,7 +50,7 @@ export type Options = Omit<
 export default ({
   include,
   exclude,
-  sourceMap: _sourceMap,
+  sourceMap = true,
   optimizeDeps,
   tsconfig,
   loaders: _loaders,
@@ -95,7 +95,6 @@ export default ({
 
   let optimizeDepsResult: OptimizeDepsResult | undefined
   let cwd = process.cwd()
-  let sourceMap = !!_sourceMap
 
   return {
     name: 'esbuild',
@@ -104,10 +103,6 @@ export default ({
       if (context) {
         cwd = context
       }
-      return null
-    },
-    outputOptions({ sourcemap }) {
-      sourceMap = _sourceMap ?? !!sourcemap
       return null
     },
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -95,7 +95,7 @@ export default ({
 
   let optimizeDepsResult: OptimizeDepsResult | undefined
   let cwd = process.cwd()
-  let sourceMap = false
+  let sourceMap = !!_sourceMap
 
   return {
     name: 'esbuild',

--- a/src/minify.ts
+++ b/src/minify.ts
@@ -18,7 +18,7 @@ export type Options = Omit<TransformOptions, 'sourcemap'> & {
 }
 
 export const getRenderChunk = ({
-  sourceMap,
+  sourceMap = true,
   ...options
 }: Options): RenderChunkHook =>
   async function (code, _, rollupOptions) {
@@ -32,7 +32,7 @@ export const getRenderChunk = ({
       const result = await transform(code, {
         format,
         loader: 'js',
-        sourcemap: sourceMap !== false,
+        sourcemap: sourceMap,
         ...options,
       })
       await warn(this, result.warnings)
@@ -46,15 +46,12 @@ export const getRenderChunk = ({
     return null
   }
 
-export const minify = (options: Options = {}): Plugin => {
-  let sourceMap = false
+export const minify = ({
+  sourceMap = true,
+  ...options
+}: Options = {}): Plugin => {
   return {
     name: 'esbuild-minify',
-
-    outputOptions({ sourcemap }) {
-      sourceMap = options.sourceMap ?? !!sourcemap
-      return null
-    },
 
     renderChunk: getRenderChunk({
       minify: true,

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -34,18 +34,21 @@ const build = async ({
   rollupPlugins = [],
   dir = '.',
   format = 'esm',
+  external,
 }: {
   input?: string | string[]
   sourcemap?: boolean
   rollupPlugins?: RollupPlugin[]
   dir?: string
   format?: ModuleFormat
+  external?: string[]
 } = {}) => {
   const build = await rollup({
     input: [...(Array.isArray(input) ? input : [input])].map((v) =>
       path.resolve(dir, v)
     ),
     plugins: rollupPlugins,
+    external,
   })
   const { output } = await build.generate({
     format,
@@ -447,6 +450,7 @@ describe('esbuild plugin', () => {
       input: './fixture/index.jsx',
       dir,
       rollupPlugins: [esbuild({})],
+      external: ['react/jsx-runtime'],
     })
     expect(output[0].code).toMatchInlineSnapshot(`
       "import { jsx } from 'react/jsx-runtime';
@@ -507,7 +511,7 @@ describe('esbuild plugin', () => {
     expect(mockEsbuildTransform).toHaveBeenCalledWith(
       expect.any(String),
       expect.objectContaining({
-        sourcemap: false,
+        sourcemap: true,
       })
     )
 


### PR DESCRIPTION
Currently the plugin will always transform the code with `sourcemap: false`, because the `outputOptions` hook runs after the `transform` hook. I've adapted this behavior in this PR and added tests

should also fix #329 and fix #333