### PR TITLE
Update README to be in sync with latest release

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ export default {
 ```
 
 - `include` and `exclude` can be `String | RegExp | Array[...String|RegExp]`, when supplied it will override default values.
-- It uses `jsxFactory`, `jsxFragmentFactory` and `target` options from your `tsconfig.json` as default values.
+- It uses `jsx`, `jsxDev`, `jsxFactory`, `jsxFragmentFactory` and `target` options from your `tsconfig.json` as default values.
 
 ### Declaration File
 


### PR DESCRIPTION
[4.10.0](https://github.com/egoist/rollup-plugin-esbuild/releases/tag/v4.10.0) introduced a change which infers more options from the project's `tsconfig.json`.

This should have been a breaking change IMO, but it can be mitigated with a mention in the README.