### PR TITLE
fix: bundle ts-essentials

### DIFF
--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -3,6 +3,6 @@ import { defineConfig } from 'tsup'
 export default defineConfig({
   entry: ['src/index.ts'],
   format: ['esm', 'cjs'],
-  dts: true,
+  dts: { resolve: true },
   clean: true,
 })


### PR DESCRIPTION
This was previously done but got lost with the migration to using tsup
config file.
