### PR TITLE
feat: extend default loaders

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -19,8 +19,12 @@ export { minify }
 const debugOptimizeDeps = createDebug('rpe:optimize-deps')
 
 const defaultLoaders: { [ext: string]: Loader } = {
+  '.cjs': 'js',
+  '.cts': 'ts',
   '.js': 'js',
   '.jsx': 'jsx',
+  '.mjs': 'js',
+  '.mts': 'ts',
   '.ts': 'ts',
   '.tsx': 'tsx',
 }


### PR DESCRIPTION
This PR adds 4 new extensions to the default loaders that are commonly used in dual packages and other "complex environments" where CJS and ESM have to coexist (mostly in NodeJS projects).

Although this property is extensible, the current defaults have to be overridden quite often.